### PR TITLE
PHP 8.3 support

### DIFF
--- a/.github/workflows/full-checks.yml
+++ b/.github/workflows/full-checks.yml
@@ -24,6 +24,7 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
         operating-system:
           - "ubuntu-22.04"
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Library to help make testing of PHPStan rules easier",
   "type": "library",
   "require": {
-    "php": ">=8.0 <8.3",
+    "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
     "phpstan/phpstan": "^1.6"
   },
   "require-dev": {


### PR DESCRIPTION
Configures support for PHP 8.3

running the ci-tools did not appear to give any issues for this.

Let me know if I missed something or not to change something additionally.
