### PR TITLE
Allow phpstan v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
-    "phpstan/phpstan": "^1.6"
+    "phpstan/phpstan": "^1.6 || ^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0",

--- a/tests/Integration/NoGotoPhpstanRule.php
+++ b/tests/Integration/NoGotoPhpstanRule.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Goto_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
 
 /** @implements Rule<Goto_> */
 final class NoGotoPhpstanRule implements Rule
@@ -19,6 +20,10 @@ final class NoGotoPhpstanRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        return ['goto statement is not allowed. Label: '.$node->name->toString()];
+        return [
+            RuleErrorBuilder::message('goto statement is not allowed. Label: '.$node->name->toString())
+                ->identifier('test.gotoNotAllowed')
+                ->build(),
+        ];
     }
 }


### PR DESCRIPTION
I think we can keep phpstan v1 support for now. Closes https://github.com/DaveLiddament/phpstan-rule-test-helper/pull/7